### PR TITLE
* Made bag objects raise TypeError when used as dictionary keys, by maki...

### DIFF
--- a/collections_extended/bags.py
+++ b/collections_extended/bags.py
@@ -1,11 +1,12 @@
 import heapq
 from operator import itemgetter
-from collections import Sized, Iterable, Container, Hashable
+from collections import Set, MutableSet, Hashable
+import unittest
 
 from . import _compat
 
 
-class _basebag(Sized, Iterable, Container):
+class _basebag(Set):
 	"""
 	Base class for bag and frozenbag.	Is not mutable and not hashable, so there's
 	no reason to use this instead of either bag or frozenbag.
@@ -340,7 +341,7 @@ class _basebag(Sized, Iterable, Container):
 		return (self - other) | (other - self)
 
 
-class bag(_basebag):
+class bag(_basebag, MutableSet):
 	"""bag is a mutable _basebag.
 
 	Thus not hashable and unusable for dict keys or in other sets.
@@ -458,19 +459,40 @@ class frozenbag(_basebag, Hashable):
 		is identical to _abcoll.Set._hash
 		We can't call it directly because Python2 raises a TypeError.
 		"""
-		MAX = _compat.maxint
-		MASK = 2 * MAX + 1
-		n = len(self)
-		h = 1927868237 * (n + 1)
-		h &= MASK
-		for x in self:
-			hx = hash(x)
-			h ^= (hx ^ (hx << 16) ^ 89869747) * 3644798167
-			h &= MASK
-		h = h * 69069 + 907133923
-		h &= MASK
-		if h > MAX:
-			h -= MASK + 1
-		if h == -1:
-			h = 590923713
-		return h
+		return self._hash()
+
+
+class MultisetHashabilityTest(unittest.TestCase):
+	def testHashability(self):
+		"""
+		Since Multiset is mutable and FronzeMultiset is hashable, the second
+		should be usable for dictionary keys and the second should raise a key
+		or value error when used as a key or placed in a set.
+		"""
+		a = bag([1,2,3])  # Mutable multiset.
+		b = frozenbag([1, 1, 2, 3])	 # prototypical frozen multiset.
+
+		c = frozenbag([4, 4, 5, 5, b, b])  # make sure we can nest them
+		d = frozenbag([4, frozenbag([1, 3, 2, 1]), 4, 5, b, 5])
+		# c and d are the same; make sure nothing weird happes to hashes.
+		self.assertEqual(c, d) # Make sure both constructions work.
+
+		dic = {}
+		dic[b] = 3
+		dic[c] = 5
+		dic[d] = 7
+		self.assertEqual(len(dic), 2) # Make sure no duplicates in dictionary.
+		# Make sure TypeErrors are raised when using mutable bags for keys.
+		with self.assertRaises(TypeError):
+			dic[a] = 4
+		with self.assertRaises(TypeError):
+			s = set([a])
+		with self.assertRaises(TypeError):
+			t = frozenbag([a, 1])
+		with self.assertRaises(TypeError):
+			w = bag([a,1])
+		# test commutativity of multiset instantiation.
+		self.assertEqual(bag([4, 4, 5, 5, c]), bag([4, 5, d, 4, 5]))
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
Fixed inheritance problems in _basebag, bag, and frozenbag:
* Python now raises type error when using a bag object as a dict key or adding it to a set, by inheriting from MutableSet.
* Made _basebag inherit from Set, so that the self._hash() method call works for frozenbags.
* Made frozenbag inherit from Hashable.
* Added unit test to demonstrate the TypeError which was not previously raised.