### PR TITLE
add RangeMap.end, RangeMap.start and tests

### DIFF
--- a/collections_extended/range_map.py
+++ b/collections_extended/range_map.py
@@ -296,6 +296,19 @@ class RangeMap(Mapping):
 		self._keys = [None]
 		self._values = [_empty]
 
+	@property
+	def start(self):
+		"""Get the start key of the first range. None if RangeMap is empty or unbounded to the left."""
+		try:
+			return self._keys[1]
+		except:
+			return None
+
+	@property
+	def end(self):
+		"""Get the stop key of the last range. None if RangeMap is empty or unbounded to the right."""
+		return self._keys[-1]
+
 	def __eq__(self, other):
 		if isinstance(other, RangeMap):
 			return (

--- a/tests/test_range_map.py
+++ b/tests/test_range_map.py
@@ -521,3 +521,20 @@ def test_clear():
 		))
 	rm.clear()
 	assert rm == RangeMap()
+
+
+def test_start():
+	assert RangeMap().start is None
+	rm = RangeMap.from_iterable((
+		(1, 2, 'a'),
+		(4, 5, 'b'),
+		))
+	assert rm.start == 1
+
+
+def test_end():
+	rm = RangeMap.from_iterable((
+		(1, 2, 'a'),
+		(4, 5, 'b'),
+		))
+	assert rm.end == 5


### PR DESCRIPTION
Ability to easily get start and end of rangemap. Returns `None` for empty/unbounded cases.

```python
def test_start():
	rm = RangeMap.from_iterable((
		(1, 2, 'a'),
		(4, 5, 'b'),
		))
	assert rm.start == 1


def test_end():
	rm = RangeMap.from_iterable((
		(1, 2, 'a'),
		(4, 5, 'b'),
		))
	assert rm.end == 5
```